### PR TITLE
fix(modal): Fixing query used to select focus-able elements.

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -304,7 +304,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
 
         function findFocusableElements() {
           // Add all elements we want to include in our selection
-          var focusableElements = 'a:not([disabled]), button:not([disabled]), input[type=text]:not([disabled]), [tabindex]:not([disabled]):not([tabindex="-1"])';
+          var focusableElements = 'a:not([disabled]), button:not([disabled]), input:not([disabled]), [tabindex]:not([disabled]):not([tabindex="-1"])';
           if (document.activeElement) {
             var focusable = Array.prototype.filter.call(modalElement[0].querySelectorAll(focusableElements),
               function (element) {


### PR DESCRIPTION
With current selector only the input elements of type text are being focused and the rest (checkbox, radio button) are not receiving focus when navigating using keyboard in the open modal.

Removed the attribute selector(type="text") from the query, to fix the functionality.