### PR TITLE
fix(datepicker): Displaying Date for timezone UTC.

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -682,7 +682,13 @@ angular.module('mgcrea.ngStrap.datepicker', [
           //   var today = new Date();
           //   date = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0);
           // }
-          controller.$dateValue = dateParser.timezoneOffsetAdjust(date, options.timezone);
+          //do not adjust date if timezone is UTC
+          if (options.timezone == 'UTC') {
+            controller.$dateValue = date;
+          } else {
+            controller.$dateValue = dateParser.timezoneOffsetAdjust(date, options.timezone);
+          }
+
           return getDateFormattedString();
         });
 
@@ -820,7 +826,13 @@ angular.module('mgcrea.ngStrap.datepicker', [
           //   var today = new Date();
           //   date = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0);
           // }
-          controller.$dateValue = dateParser.timezoneOffsetAdjust(date, options.timezone);
+          //Donot adjust date if timezone is UTC
+          if (options.timezone == 'UTC') {
+            controller.$dateValue = date;
+          } else {
+            controller.$dateValue = dateParser.timezoneOffsetAdjust(date, options.timezone);
+          }
+
           return getDateFormattedString();
         });
 


### PR DESCRIPTION
Exempting datepicker field with timezone 'UTC' from timezone adjustment.

With current logic, a date saved in UTC when retrieved to display in a datepicker field is adjusted respective to the user's timezone and due to this the date is displayed wrongly.