### PR TITLE
fix(datepicker): unable to select the same date as minDate

### DIFF
--- a/src/helpers/date-parser.js
+++ b/src/helpers/date-parser.js
@@ -165,7 +165,11 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
           var today = new Date();
           date = new Date(today.getFullYear(), today.getMonth(), today.getDate() + (key === 'maxDate' ? 1 : 0), 0, 0, 0, (key === 'minDate' ? 0 : -1));
         } else if (angular.isString(value) && value.match(/^".+"$/)) { // Support {{ dateObj }}
-          date = new Date(value.substr(1, value.length - 2));
+          if (value.match(/Z/)) {
++           date = new Date(value.substr(1, value.length - 3));
++         } else {
++           date = new Date(value.substr(1, value.length - 2));
++         }
         } else if (isNumeric(value)) {
           date = new Date(parseInt(value, 10));
         } else if (angular.isString(value) && value.length === 0) { // Reset date


### PR DESCRIPTION
Due to passing string with 'Z' into Date constructor the date value is being offset by browser's timezone which is causing the the datepicker to disable the day which is passed as minDate. Effectively not allowing to select the date which is set as minDate. This will be reproducible for user on East of UTC.

To fix the issue, checking for 'Z' in the date string and excluding it to get the Date object with the expected date.